### PR TITLE
specify imageSize to imageService due to default one maximum is 512

### DIFF
--- a/tools-gae/src/main/java/com/wadpam/open/web/BlobController.java
+++ b/tools-gae/src/main/java/com/wadpam/open/web/BlobController.java
@@ -97,7 +97,8 @@ public class BlobController extends AbstractRestController {
     @RequestMapping(value="upload", method= RequestMethod.POST)
     @ResponseBody
     public Map<String, List<String>> uploadCallback(HttpServletRequest request,
-                                              @PathVariable String domain) {
+                                              @PathVariable String domain,
+                                              @RequestParam(required=false) Integer imageSize) {
         LOG.debug("Blobstore upload callback");
 
         // Get all uploaded blob info records
@@ -119,7 +120,13 @@ public class BlobController extends AbstractRestController {
                     // we want to serve directly from ImagesService,
                     // to avoid involving the GAE app, avoid spinning up instances,
                     // and to use the awesome Google CDN.
+                    
                     ServingUrlOptions suo = ServingUrlOptions.Builder.withBlobKey(blobKey);
+                    
+                    if (null !=imageSize) {
+                        LOG.debug(" specific image size {}", imageSize);
+                        suo=suo.imageSize(imageSize);
+                    }
                     accessUrl = imagesService.getServingUrl(suo);
                 }
                 else {


### PR DESCRIPTION
New Behaviour:-
Now, a blobstore image is served BY DEFAULT in a resized form to a maximum dimension of 512px
